### PR TITLE
fix: 优化websocket默认路由

### DIFF
--- a/hula-im-service/src/main/java/com/hula/core/websocket/NettyWebSocketServer.java
+++ b/hula-im-service/src/main/java/com/hula/core/websocket/NettyWebSocketServer.java
@@ -89,7 +89,8 @@ public class NettyWebSocketServer {
                          *  4. WebSocketServerProtocolHandler 核心功能是把 http协议升级为 ws 协议，保持长连接；
                          *      是通过一个状态码 101 来切换的
                          */
-                        pipeline.addLast(new WebSocketServerProtocolHandler("/"));
+                        // 添加 /websocket路由用于识别websocket请求, 方便在nginx中作localtion 配置
+                        pipeline.addLast(new WebSocketServerProtocolHandler("/websocket"));
                         // 自定义handler ，处理业务逻辑
                         pipeline.addLast(NETTY_WEB_SOCKET_SERVER_HANDLER);
                     }


### PR DESCRIPTION
修改/路由为/websocket, 方便nginx根据路由规则作ws升级配置