### PR TITLE
fix:查询ai大模型api密钥列表接口返回平台字段，否则前端无法进行回填平台字段无法提交，解决对应github上的issue#383

### DIFF
--- a/luohuo-cloud/luohuo-ai/luohuo-ai-biz/src/main/java/com/luohuo/flex/ai/controller/model/AiApiKeyController.java
+++ b/luohuo-cloud/luohuo-ai/luohuo-ai-biz/src/main/java/com/luohuo/flex/ai/controller/model/AiApiKeyController.java
@@ -74,7 +74,7 @@ public class AiApiKeyController {
     @Operation(summary = "获得 API 密钥分页列表")
     public R<List<AiModelRespVO>> getApiKeySimpleList() {
         List<AiApiKeyDO> list = apiKeyService.getApiKeyList();
-        return success(convertList(list, key -> new AiModelRespVO().setId(key.getId()).setName(key.getName())));
+        return success(convertList(list, key -> new AiModelRespVO().setId(key.getId()).setName(key.getName()).setPlatform(key.getPlatform())));
     }
 
     @GetMapping("/balance")


### PR DESCRIPTION
具体描述看https://github.com/HuLaSpark/HuLa的issue#383