### PR TITLE
fix:自述文件和文档的修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 </p>
 
 <p align="center">
-  🖥️ 客户端：<a href="https://github.com/HuLaSpark/HuLa-Server">github HuLa-Server</a> | <a href="https://gitee.com/HulaSpark/HuLa-Server">gitee HuLa-Server</a>
+  🖥️ 客户端：<a href="https://github.com/HuLaSpark/HuLa">github HuLa-client</a> | <a href="https://github.com/HuLaSpark/HuLa">gitee HuLa-client</a>
 </p>
 
 <p align="center"><a href="README.en.md">English</a> | 中文</p>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 </p>
 
 <p align="center">
-  🖥️ 客户端：<a href="https://github.com/HuLaSpark/HuLa">github HuLa-client</a> | <a href="https://github.com/HuLaSpark/HuLa">gitee HuLa-client</a>
+  🖥️ 客户端：<a href="https://github.com/HuLaSpark/HuLa">github HuLa-client</a> | <a href="https://gitee.com/HuLaSpark/HuLa">gitee HuLa-client</a>
 </p>
 
 <p align="center"><a href="README.en.md">English</a> | 中文</p>

--- a/docs/install/服务端部署文档.md
+++ b/docs/install/服务端部署文档.md
@@ -7,7 +7,7 @@
 
 ## 🛠️ 启动命令
 - **提高权限**: sudo chmod -R 777 /home/docker/rocketmq
-- **开放端口**: 先去你购物服务器的平台里面的安全组里面放行mysql、redis、rocketmq部署的端口，再去1panel或宝塔下面放行
+- **开放端口**: 先去你购买服务器的平台里面的安全组里面放行mysql、redis、rocketmq部署的端口，再去1panel或宝塔下面放行
 - **执行命令**: cd /home/docker & docker-compose up -d
 - **导入mysql数据库**: install文件夹下面有一个nacos[mysql-schema.sql](mysql-schema.sql)的sql文件，需要导入到数据库里面，不然nacos启动不了
 - **重试nacos**: 如果还不行就删了nacos的容器，重新执行 docker-compose up -d


### PR DESCRIPTION
更改描述:
1. `https://github.com/HuLaSpark/HuLa-Server/blob/master/README.md` 中被描述为应指向客户端的URL实则为自指
<img width="1218" height="61" alt="圖片" src="https://github.com/user-attachments/assets/ab56fd21-41d4-4961-b3a0-af84eb8d9185" />
> 在 README_en.md中
<img width="1023" height="61" alt="圖片" src="https://github.com/user-attachments/assets/fd8b225a-82f9-4a59-8a74-f216b92e25bc" />

2. 修正安装文档中的一处错别字